### PR TITLE
Create deployment control center page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,22 @@
             padding: 0;
         }
 
+        [hidden] {
+            display: none !important;
+        }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
         body {
             font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
             background: var(--bg-gradient);
@@ -142,6 +158,11 @@
             text-decoration: none;
         }
 
+        .btn-label {
+            display: inline-flex;
+            align-items: center;
+        }
+
         .btn.primary {
             background: var(--primary);
             color: #ffffff;
@@ -211,6 +232,38 @@
             gap: 1.5rem;
         }
 
+        .summary + .window-details {
+            margin-top: 0.25rem;
+        }
+
+        .window-details {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 1rem;
+            padding: 1.1rem 1.25rem;
+            background: rgba(15, 27, 61, 0.04);
+            border-radius: var(--radius-md);
+        }
+
+        .window-details div {
+            display: grid;
+            gap: 0.35rem;
+        }
+
+        .window-details dt {
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--text-secondary);
+        }
+
+        .window-details dd {
+            margin: 0;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
         .deployment-stats {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
@@ -267,7 +320,20 @@
             border-radius: 999px;
             font-weight: 600;
             cursor: pointer;
-            transition: background 0.18s ease;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            transition: background 0.18s ease, color 0.18s ease;
+        }
+
+        .card-footer button svg {
+            width: 1rem;
+            height: 1rem;
+        }
+
+        .card-footer button[aria-pressed="true"] {
+            background: rgba(0, 184, 148, 0.18);
+            color: var(--accent);
         }
 
         .card-footer button:hover,
@@ -277,6 +343,27 @@
 
         .section {
             margin-bottom: 4rem;
+        }
+
+        .action-message {
+            margin: -0.5rem 0 3rem;
+            padding: 0.9rem 1.25rem;
+            border-radius: var(--radius-md);
+            font-size: 0.95rem;
+            font-weight: 600;
+            background: rgba(53, 102, 255, 0.12);
+            color: var(--primary);
+            box-shadow: var(--shadow);
+        }
+
+        .action-message[data-state="success"] {
+            background: rgba(0, 184, 148, 0.15);
+            color: var(--accent);
+        }
+
+        .action-message[data-state="warning"] {
+            background: rgba(255, 188, 66, 0.18);
+            color: #cc7a00;
         }
 
         .section-heading {
@@ -470,6 +557,100 @@
             font-weight: 600;
         }
 
+        dialog {
+            border: none;
+            border-radius: var(--radius-md);
+            padding: 0;
+            width: min(420px, 92vw);
+            box-shadow: var(--shadow);
+        }
+
+        dialog::backdrop {
+            background: rgba(15, 27, 61, 0.35);
+            backdrop-filter: blur(2px);
+        }
+
+        .dialog-form {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+            padding: 1.75rem;
+            background: var(--card-bg);
+        }
+
+        .dialog-header {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .dialog-header h2 {
+            font-size: 1.2rem;
+            font-weight: 600;
+        }
+
+        .dialog-close {
+            border: none;
+            background: transparent;
+            color: var(--text-secondary);
+            font-size: 1.25rem;
+            line-height: 1;
+            cursor: pointer;
+        }
+
+        .dialog-body {
+            display: grid;
+            gap: 1rem;
+        }
+
+        .dialog-field {
+            display: grid;
+            gap: 0.35rem;
+        }
+
+        .dialog-field label {
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .dialog-field input,
+        .dialog-field select,
+        .dialog-field textarea {
+            border: 1px solid rgba(217, 226, 242, 0.9);
+            border-radius: 0.75rem;
+            padding: 0.65rem 0.75rem;
+            background: var(--muted);
+            font: inherit;
+            color: var(--text-primary);
+            transition: background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+        }
+
+        .dialog-field input:focus,
+        .dialog-field select:focus,
+        .dialog-field textarea:focus {
+            outline: none;
+            border-color: rgba(53, 102, 255, 0.6);
+            box-shadow: 0 0 0 2px rgba(53, 102, 255, 0.2);
+            background: #ffffff;
+        }
+
+        .dialog-field textarea {
+            resize: vertical;
+            min-height: 5rem;
+        }
+
+        .dialog-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 0.75rem;
+        }
+
+        .dialog-actions .btn {
+            padding: 0.75rem 1.4rem;
+        }
+
         @media (max-width: 1024px) {
             header {
                 flex-direction: column;
@@ -502,12 +683,24 @@
             .section {
                 margin-bottom: 3rem;
             }
+
+            .action-message {
+                margin: 0 0 2.5rem;
+            }
         }
 
         @media (max-width: 520px) {
             .action-buttons {
                 flex-direction: column;
                 align-items: stretch;
+            }
+
+            dialog {
+                width: min(100%, 22rem);
+            }
+
+            .dialog-form {
+                padding: 1.25rem;
             }
         }
     </style>
@@ -539,14 +732,14 @@
                             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                 <path d="M9 18l6-6-6-6" />
                             </svg>
-                            View Release Plan
+                            <span class="btn-label">View release plan</span>
                         </a>
-                        <button class="btn secondary" type="button" id="scheduleButton">
+                        <button class="btn secondary" type="button" id="scheduleButton" aria-haspopup="dialog" aria-controls="scheduleDialog">
                             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                 <circle cx="12" cy="12" r="9" />
                                 <polyline points="12 7 12 12 15 15" />
                             </svg>
-                            Schedule Window
+                            <span class="btn-label">Schedule window</span>
                         </button>
                     </div>
                 </article>
@@ -568,10 +761,22 @@
                             The release candidate has passed automated smoke, regression, and security checks.
                             Final validation is scheduled ahead of production deployment.
                         </p>
+                        <dl class="window-details">
+                            <div>
+                                <dt>Target start</dt>
+                                <dd>
+                                    <time id="launch-window" aria-live="polite">Scheduling…</time>
+                                </dd>
+                            </div>
+                            <div>
+                                <dt>Window length</dt>
+                                <dd><span id="window-duration" data-minutes="45">45 minutes</span></dd>
+                            </div>
+                        </dl>
                         <div class="deployment-stats">
                             <div class="stat">
                                 <span>Launch In</span>
-                                <span id="launch-countdown">--:--:--</span>
+                                <span id="launch-countdown" role="timer" aria-live="off" aria-label="Time remaining until launch window opens">--h --m --s</span>
                             </div>
                             <div class="stat">
                                 <span>Change Sets</span>
@@ -588,10 +793,18 @@
                             Deployment manager
                             <strong>Alex Rivers</strong>
                         </span>
-                        <button type="button" id="notifyButton">Notify team</button>
+                        <button type="button" id="notifyButton" aria-haspopup="dialog" aria-controls="notifyDialog">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                                <polyline points="15 10 12 13 9 10" />
+                            </svg>
+                            <span class="btn-label">Notify team</span>
+                        </button>
                     </div>
                 </aside>
             </section>
+
+            <div class="action-message" id="actionMessage" role="status" aria-live="polite" aria-atomic="true" hidden></div>
 
             <section class="section" id="release-overview">
                 <div class="section-heading">
@@ -721,38 +934,351 @@
         </footer>
     </div>
 
+    <dialog id="scheduleDialog" aria-labelledby="scheduleDialogTitle">
+        <form id="scheduleForm" class="dialog-form">
+            <div class="dialog-header">
+                <h2 id="scheduleDialogTitle">Schedule deployment window</h2>
+                <button type="button" class="dialog-close" data-close="scheduleDialog" aria-label="Close scheduling form">&times;</button>
+            </div>
+            <div class="dialog-body">
+                <div class="dialog-field">
+                    <label for="deployment-start">Start time</label>
+                    <input type="datetime-local" id="deployment-start" name="start" required />
+                </div>
+                <div class="dialog-field">
+                    <label for="deployment-duration">Window length</label>
+                    <select id="deployment-duration" name="duration">
+                        <option value="45" selected>45 minutes</option>
+                        <option value="60">60 minutes</option>
+                        <option value="90">90 minutes</option>
+                    </select>
+                </div>
+                <div class="dialog-field">
+                    <label for="deployment-notes">Notes</label>
+                    <textarea id="deployment-notes" name="notes" rows="3" placeholder="Share context for the window request."></textarea>
+                </div>
+            </div>
+            <div class="dialog-actions">
+                <button type="button" class="btn secondary" data-close="scheduleDialog">Cancel</button>
+                <button type="submit" class="btn primary">Submit request</button>
+            </div>
+        </form>
+    </dialog>
+
+    <dialog id="notifyDialog" aria-labelledby="notifyDialogTitle">
+        <form id="notifyForm" class="dialog-form">
+            <div class="dialog-header">
+                <h2 id="notifyDialogTitle">Notify deployment team</h2>
+                <button type="button" class="dialog-close" data-close="notifyDialog" aria-label="Close notification form">&times;</button>
+            </div>
+            <div class="dialog-body">
+                <div class="dialog-field">
+                    <label for="notify-channel">Channel</label>
+                    <input type="text" id="notify-channel" name="channel" value="#release-ready" required />
+                </div>
+                <div class="dialog-field">
+                    <label for="notify-audience">Audience</label>
+                    <select id="notify-audience" name="audience">
+                        <option value="engineering" selected>Engineering</option>
+                        <option value="product">Product &amp; design</option>
+                        <option value="company">Company-wide</option>
+                    </select>
+                </div>
+                <div class="dialog-field">
+                    <label for="notify-summary">Summary</label>
+                    <textarea id="notify-summary" name="summary" rows="3" placeholder="Draft the message that will be sent to the team."></textarea>
+                </div>
+            </div>
+            <div class="dialog-actions">
+                <button type="button" class="btn secondary" data-close="notifyDialog">Cancel</button>
+                <button type="submit" class="btn primary">Send notification</button>
+            </div>
+        </form>
+    </dialog>
+
     <script>
         const launchCountdown = document.getElementById('launch-countdown');
+        const launchWindow = document.getElementById('launch-window');
+        const windowDuration = document.getElementById('window-duration');
         const scheduleButton = document.getElementById('scheduleButton');
         const notifyButton = document.getElementById('notifyButton');
+        const scheduleButtonLabel = scheduleButton ? scheduleButton.querySelector('.btn-label') : null;
+        const notifyButtonLabel = notifyButton ? notifyButton.querySelector('.btn-label') : null;
         const currentYear = document.getElementById('current-year');
+        const actionMessage = document.getElementById('actionMessage');
+        const scheduleDialog = document.getElementById('scheduleDialog');
+        const notifyDialog = document.getElementById('notifyDialog');
+        const scheduleForm = document.getElementById('scheduleForm');
+        const notifyForm = document.getElementById('notifyForm');
+        const heroCard = document.querySelector('.hero-card');
+        const defaultWindowMinutes = windowDuration && windowDuration.dataset.minutes ? windowDuration.dataset.minutes : '45';
 
-        currentYear.textContent = new Date().getFullYear();
+        let messageTimeoutId;
+        let countdownInterval;
+        let countdownCompleted = false;
 
-        const target = new Date();
-        target.setHours(target.getHours() + 4, 0, 0, 0);
-
-        function updateCountdown() {
-            const now = new Date();
-            const diff = Math.max(0, target - now);
-
-            const hours = String(Math.floor(diff / (1000 * 60 * 60))).padStart(2, '0');
-            const minutes = String(Math.floor((diff / (1000 * 60)) % 60)).padStart(2, '0');
-            const seconds = String(Math.floor((diff / 1000) % 60)).padStart(2, '0');
-
-            launchCountdown.textContent = `${hours}:${minutes}:${seconds}`;
+        if (currentYear) {
+            currentYear.textContent = new Date().getFullYear();
         }
 
-        updateCountdown();
-        setInterval(updateCountdown, 1000);
+        function formatDateTime(date) {
+            try {
+                return new Intl.DateTimeFormat(undefined, {
+                    dateStyle: 'full',
+                    timeStyle: 'short',
+                }).format(date);
+            } catch (error) {
+                return date.toLocaleString();
+            }
+        }
 
-        scheduleButton.addEventListener('click', () => {
-            alert('Schedule sent to calendar. Team will be notified once approved.');
+        function formatDatetimeLocalValue(date) {
+            const pad = (value) => String(value).padStart(2, '0');
+            return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+        }
+
+        function getLaunchTarget() {
+            const rawTarget = heroCard && heroCard.dataset ? heroCard.dataset.launchTarget : '';
+            if (rawTarget) {
+                const parsed = new Date(rawTarget);
+                if (!Number.isNaN(parsed.valueOf())) {
+                    return parsed;
+                }
+            }
+
+            const now = new Date();
+            const targetDate = new Date(now);
+            targetDate.setHours(16, 30, 0, 0);
+            const dayDifference = (4 - now.getDay() + 7) % 7;
+            if (dayDifference === 0 && targetDate <= now) {
+                targetDate.setDate(targetDate.getDate() + 7);
+            } else if (dayDifference !== 0) {
+                targetDate.setDate(targetDate.getDate() + dayDifference);
+            }
+            return targetDate;
+        }
+
+        let target = getLaunchTarget();
+
+        function setLaunchWindowText(date) {
+            if (!launchWindow) return;
+            launchWindow.textContent = formatDateTime(date);
+            launchWindow.dateTime = date.toISOString();
+        }
+
+        setLaunchWindowText(target);
+
+        function showMessage(text, state) {
+            if (!actionMessage) return;
+            actionMessage.textContent = text;
+            actionMessage.dataset.state = state || 'info';
+            actionMessage.hidden = false;
+            window.clearTimeout(messageTimeoutId);
+            messageTimeoutId = window.setTimeout(() => {
+                actionMessage.hidden = true;
+            }, 6000);
+        }
+
+        function updateCountdown() {
+            if (!launchCountdown) return;
+            const now = new Date();
+            const diff = target.getTime() - now.getTime();
+
+            if (diff <= 0) {
+                launchCountdown.textContent = '00h 00m 00s';
+                launchCountdown.setAttribute('aria-label', 'Launch window is now open');
+                if (!countdownCompleted) {
+                    showMessage('Launch window is now open. Monitor telemetry before advancing.', 'success');
+                    countdownCompleted = true;
+                }
+                if (countdownInterval) {
+                    window.clearInterval(countdownInterval);
+                    countdownInterval = null;
+                }
+                return;
+            }
+
+            const totalSeconds = Math.floor(diff / 1000);
+            const days = Math.floor(totalSeconds / 86400);
+            const hours = Math.floor((totalSeconds % 86400) / 3600);
+            const minutes = Math.floor((totalSeconds % 3600) / 60);
+            const seconds = totalSeconds % 60;
+            const totalHours = Math.floor(totalSeconds / 3600);
+
+            let formatted;
+            if (days > 0) {
+                formatted = `${days}d ${String(hours).padStart(2, '0')}h ${String(minutes).padStart(2, '0')}m`;
+            } else {
+                formatted = `${String(totalHours).padStart(2, '0')}h ${String(minutes).padStart(2, '0')}m ${String(seconds).padStart(2, '0')}s`;
+            }
+            launchCountdown.textContent = formatted;
+
+            const ariaParts = [];
+            if (days > 0) {
+                ariaParts.push(`${days} ${days === 1 ? 'day' : 'days'}`);
+            }
+            const hoursForLabel = days > 0 ? hours : totalHours;
+            if (hoursForLabel > 0) {
+                ariaParts.push(`${hoursForLabel} ${hoursForLabel === 1 ? 'hour' : 'hours'}`);
+            }
+            if (minutes > 0) {
+                ariaParts.push(`${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`);
+            }
+            if (days === 0 && seconds > 0) {
+                ariaParts.push(`${seconds} ${seconds === 1 ? 'second' : 'seconds'}`);
+            }
+            launchCountdown.setAttribute('aria-label', `${ariaParts.join(', ')} remaining until launch window opens`);
+        }
+
+        function startCountdown() {
+            if (countdownInterval) {
+                window.clearInterval(countdownInterval);
+            }
+            updateCountdown();
+            if (target > new Date()) {
+                countdownCompleted = false;
+                countdownInterval = window.setInterval(updateCountdown, 1000);
+            }
+        }
+
+        startCountdown();
+
+        function attachDialogCloseFocus(dialog) {
+            if (!dialog) return;
+            dialog.addEventListener('close', () => {
+                const triggerId = dialog.dataset ? dialog.dataset.trigger : '';
+                if (triggerId) {
+                    const triggerElement = document.getElementById(triggerId);
+                    if (triggerElement) {
+                        triggerElement.focus();
+                    }
+                    dialog.dataset.trigger = '';
+                }
+            });
+        }
+
+        attachDialogCloseFocus(scheduleDialog);
+        attachDialogCloseFocus(notifyDialog);
+
+        document.querySelectorAll('[data-close]').forEach((button) => {
+            button.addEventListener('click', () => {
+                const dialogId = button.dataset.close;
+                const dialogElement = document.getElementById(dialogId);
+                if (dialogElement) {
+                    dialogElement.close();
+                }
+            });
         });
 
-        notifyButton.addEventListener('click', () => {
-            alert('Notification sent to release channel.');
-        });
+        if (scheduleButton && scheduleDialog && scheduleForm) {
+            scheduleButton.addEventListener('click', () => {
+                if (typeof scheduleDialog.showModal !== 'function') {
+                    showMessage('Unable to open the scheduling form in this browser.', 'warning');
+                    return;
+                }
+
+                const startInput = scheduleForm.querySelector('#deployment-start');
+                if (startInput) {
+                    startInput.value = formatDatetimeLocalValue(target);
+                }
+
+                const durationSelect = scheduleForm.querySelector('#deployment-duration');
+                if (durationSelect && windowDuration) {
+                    durationSelect.value = windowDuration.dataset.minutes || defaultWindowMinutes;
+                }
+
+                scheduleDialog.dataset.trigger = scheduleButton.id;
+                scheduleDialog.showModal();
+            });
+
+            scheduleForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+                const formData = new FormData(scheduleForm);
+                const startValue = formData.get('start');
+                const durationValue = formData.get('duration') || defaultWindowMinutes;
+                const notesValue = (formData.get('notes') || '').toString().trim();
+
+                if (!startValue) {
+                    showMessage('Select a start time to schedule the deployment window.', 'warning');
+                    return;
+                }
+
+                const newTarget = new Date(startValue);
+                if (Number.isNaN(newTarget.valueOf())) {
+                    showMessage('The selected start time could not be parsed. Try a different value.', 'warning');
+                    return;
+                }
+
+                target = newTarget;
+                setLaunchWindowText(target);
+                if (windowDuration) {
+                    windowDuration.dataset.minutes = durationValue;
+                    const minutesNumber = Number.parseInt(durationValue, 10);
+                    if (Number.isNaN(minutesNumber)) {
+                        windowDuration.textContent = durationValue;
+                    } else {
+                        windowDuration.textContent = `${minutesNumber} minute${minutesNumber === 1 ? '' : 's'}`;
+                    }
+                }
+
+                if (scheduleButtonLabel) {
+                    scheduleButtonLabel.textContent = 'Update window';
+                }
+
+                scheduleDialog.close();
+                scheduleForm.reset();
+                startCountdown();
+
+                const minutesNumber = Number.parseInt(durationValue, 10);
+                const durationText = Number.isNaN(minutesNumber)
+                    ? durationValue
+                    : `${minutesNumber} minute${minutesNumber === 1 ? '' : 's'}`;
+                let message = `Deployment window request submitted for ${formatDateTime(target)} (${durationText}).`;
+                if (notesValue) {
+                    message += ' Notes captured for the release log.';
+                }
+                showMessage(message, 'success');
+            });
+        }
+
+        if (notifyButton && notifyDialog && notifyForm) {
+            notifyButton.addEventListener('click', () => {
+                if (typeof notifyDialog.showModal !== 'function') {
+                    showMessage('Unable to open the notification form in this browser.', 'warning');
+                    return;
+                }
+
+                const summaryField = notifyForm.querySelector('#notify-summary');
+                if (summaryField && summaryField.value.trim().length === 0) {
+                    summaryField.value = `Deployment window scheduled for ${formatDateTime(target)}.`;
+                }
+
+                notifyDialog.dataset.trigger = notifyButton.id;
+                notifyDialog.showModal();
+            });
+
+            notifyForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+                const formData = new FormData(notifyForm);
+                const channel = (formData.get('channel') || '#release-ready').toString();
+                const audience = (formData.get('audience') || 'engineering').toString();
+                const summary = (formData.get('summary') || '').toString().trim();
+
+                notifyDialog.close();
+                notifyForm.reset();
+
+                let message = `Notification prepared for ${channel} (${audience}).`;
+                if (summary) {
+                    message += ` Message: ${summary}`;
+                }
+                showMessage(message, 'success');
+
+                if (notifyButtonLabel) {
+                    notifyButtonLabel.textContent = 'Notify again';
+                }
+                notifyButton.setAttribute('aria-pressed', 'true');
+            });
+        }
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,320 +1,757 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document Approval System</title>
-    <meta name="description" content="Streamlined document review and approval workflow interface">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deployment Control Center</title>
+    <meta name="description" content="Deployment control center dashboard with release status, environment health, and launch checklist." />
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
+        :root {
+            --bg: #f7f9fc;
+            --bg-gradient: linear-gradient(135deg, #f4f7fb 0%, #eef3fc 45%, #ffffff 100%);
+            --card-bg: #ffffff;
+            --card-border: #d9e2f2;
+            --text-primary: #0f1b3d;
+            --text-secondary: #4f5d7a;
+            --primary: #3566ff;
+            --primary-dark: #274dcc;
+            --accent: #00b894;
+            --muted: #eef2fb;
+            --shadow: 0 20px 45px -24px rgba(22, 35, 70, 0.35);
+            --radius-lg: 1.5rem;
+            --radius-md: 1rem;
+            --radius-sm: 0.75rem;
         }
 
-        :root {
-            /* Document approval theme colors */
-            --background: hsl(0, 0%, 97%);
-            --foreground: hsl(220, 9%, 20%);
-            --card: hsl(0, 0%, 100%);
-            --card-foreground: hsl(220, 9%, 20%);
-            --border: hsl(220, 13%, 91%);
-            
-            /* Blue approval theme */
-            --primary: hsl(213, 94%, 68%);
-            --primary-foreground: hsl(0, 0%, 100%);
-            --secondary: hsl(220, 14%, 96%);
-            --secondary-foreground: hsl(220, 9%, 46%);
-            
-            /* Custom document theme tokens */
-            --doc-bg: linear-gradient(135deg, hsl(220, 14%, 97%) 0%, hsl(220, 14%, 95%) 100%);
-            --doc-icon: hsl(213, 94%, 68%);
-            --doc-heading: hsl(220, 9%, 20%);
-            --doc-subtitle: hsl(220, 9%, 46%);
-            --approve-btn: hsl(213, 94%, 68%);
-            --approve-btn-hover: hsl(213, 94%, 60%);
-            --reject-btn: hsl(0, 0%, 100%);
-            --reject-btn-hover: hsl(220, 14%, 96%);
-            --shadow-soft: 0 4px 20px -4px hsl(220, 9%, 20%, 0.08);
-            --shadow-button: 0 2px 8px -2px hsl(213, 94%, 68%, 0.2);
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
         }
 
         body {
-            background: var(--doc-bg);
-            color: var(--foreground);
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: var(--bg-gradient);
+            color: var(--text-primary);
             min-height: 100vh;
-            line-height: 1.5;
         }
 
-        .container {
+        .page {
             min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 1rem;
-        }
-
-        .content {
-            max-width: 28rem;
-            width: 100%;
-            text-align: center;
-        }
-
-        .icon-container {
-            margin-bottom: 2rem;
-            display: flex;
-            justify-content: center;
-        }
-
-        .icon-circle {
-            width: 4rem;
-            height: 4rem;
-            border-radius: 50%;
-            background-color: hsl(213, 100%, 97%);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .icon {
-            width: 2rem;
-            height: 2rem;
-            color: var(--doc-icon);
-        }
-
-        .heading {
-            font-size: 1.5rem;
-            font-weight: 600;
-            color: var(--doc-heading);
-            margin-bottom: 1rem;
-        }
-
-        .subtitle {
-            color: var(--doc-subtitle);
-            margin-bottom: 2rem;
-        }
-
-        .button-container {
             display: flex;
             flex-direction: column;
-            gap: 0.75rem;
         }
 
-        .button {
-            width: 100%;
-            height: 3rem;
-            border-radius: 0.5rem;
-            border: none;
-            font-size: 1rem;
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1.75rem 6vw 1.25rem;
+        }
+
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.9rem;
+        }
+
+        .logo-badge {
+            width: 2.85rem;
+            height: 2.85rem;
+            border-radius: 1.1rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(53, 102, 255, 0.1);
+            color: var(--primary);
+            font-weight: 700;
+            letter-spacing: 0.08em;
+        }
+
+        .logo span:last-child {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        nav {
+            display: flex;
+            align-items: center;
+            gap: 1.75rem;
+        }
+
+        nav a {
+            text-decoration: none;
+            color: var(--text-secondary);
             font-weight: 500;
-            cursor: pointer;
+            font-size: 0.95rem;
+            transition: color 0.2s ease;
+        }
+
+        nav a:hover,
+        nav a:focus {
+            color: var(--primary);
+        }
+
+        main {
+            flex: 1;
+            padding: 0 6vw 4rem;
+        }
+
+        .hero {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 3.5rem;
+            align-items: center;
+            padding: 2rem 0 4rem;
+        }
+
+        .hero h1 {
+            font-size: clamp(2.5rem, 4vw, 3.5rem);
+            line-height: 1.05;
+            font-weight: 700;
+            margin-bottom: 1.25rem;
+        }
+
+        .hero p {
+            font-size: 1.1rem;
+            line-height: 1.6;
+            color: var(--text-secondary);
+            max-width: 36rem;
+        }
+
+        .action-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.85rem;
+            margin-top: 2rem;
+        }
+
+        .btn {
             display: inline-flex;
             align-items: center;
             justify-content: center;
             gap: 0.5rem;
-            transition: all 0.2s ease-in-out;
+            border: none;
+            border-radius: 999px;
+            font-weight: 600;
+            padding: 0.85rem 1.8rem;
+            font-size: 0.95rem;
+            cursor: pointer;
+            transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease;
             text-decoration: none;
         }
 
-        .button:focus {
-            outline: 2px solid var(--primary);
-            outline-offset: 2px;
+        .btn.primary {
+            background: var(--primary);
+            color: #ffffff;
+            box-shadow: 0 12px 30px -18px rgba(53, 102, 255, 0.8);
         }
 
-        .button-approve {
-            background-color: var(--approve-btn);
-            color: white;
-            box-shadow: var(--shadow-button);
+        .btn.primary:hover,
+        .btn.primary:focus {
+            transform: translateY(-2px);
+            background: var(--primary-dark);
         }
 
-        .button-approve:hover {
-            background-color: var(--approve-btn-hover);
-            transform: translateY(-1px);
+        .btn.secondary {
+            background: transparent;
+            color: var(--text-primary);
+            border: 1px solid var(--card-border);
         }
 
-        .button-reject {
-            background-color: var(--reject-btn);
-            color: var(--doc-heading);
-            border: 1px solid var(--border);
+        .btn.secondary:hover,
+        .btn.secondary:focus {
+            background: rgba(15, 27, 61, 0.05);
         }
 
-        .button-reject:hover {
-            background-color: var(--reject-btn-hover);
+        .hero-card {
+            background: var(--card-bg);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow);
+            padding: 2rem;
+            border: 1px solid rgba(217, 226, 242, 0.6);
         }
 
-        .progress-container {
-            width: 100%;
-            margin-top: 1rem;
+        .card-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1.5rem;
         }
 
-        .progress-bar {
-            width: 100%;
-            height: 0.5rem;
-            background-color: var(--secondary);
-            border-radius: 9999px;
-            overflow: hidden;
+        .card-header h2 {
+            font-size: 1.05rem;
+            font-weight: 600;
+            letter-spacing: 0.02em;
         }
 
-        .progress-fill {
-            height: 100%;
-            background-color: var(--primary);
-            border-radius: 9999px;
-            transition: width 0.3s ease-in-out;
-            width: 0%;
+        .status-badge {
+            font-size: 0.8rem;
+            font-weight: 600;
+            background: rgba(0, 184, 148, 0.12);
+            color: var(--accent);
+            padding: 0.35rem 0.9rem;
+            border-radius: 999px;
         }
 
-        .progress-text {
-            font-size: 0.875rem;
-            color: var(--doc-subtitle);
-            margin-top: 0.5rem;
+        .status-badge span {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
         }
 
-        .hidden {
-            display: none;
+        .status-badge svg {
+            width: 0.95rem;
+            height: 0.95rem;
         }
 
-        /* Responsive design */
-        @media (max-width: 640px) {
-            .content {
-                max-width: 20rem;
+        .card-body {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        .deployment-stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+            gap: 1rem;
+        }
+
+        .stat {
+            background: var(--muted);
+            border-radius: var(--radius-md);
+            padding: 1rem;
+        }
+
+        .stat span:first-child {
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--text-secondary);
+        }
+
+        .stat span:last-child {
+            display: block;
+            font-size: 1.55rem;
+            font-weight: 700;
+            margin-top: 0.35rem;
+        }
+
+        .card-footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background: rgba(53, 102, 255, 0.08);
+            border-radius: var(--radius-md);
+            padding: 1.1rem 1.25rem;
+        }
+
+        .card-footer span {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+            display: inline-flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .card-footer strong {
+            color: var(--primary);
+        }
+
+        .card-footer button {
+            border: none;
+            background: rgba(53, 102, 255, 0.15);
+            color: var(--primary);
+            padding: 0.55rem 1.2rem;
+            border-radius: 999px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.18s ease;
+        }
+
+        .card-footer button:hover,
+        .card-footer button:focus {
+            background: rgba(39, 77, 204, 0.2);
+        }
+
+        .section {
+            margin-bottom: 4rem;
+        }
+
+        .section-heading {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .section-heading h2 {
+            font-size: 1.6rem;
+            font-weight: 600;
+        }
+
+        .section-heading p {
+            color: var(--text-secondary);
+            font-size: 0.95rem;
+        }
+
+        .metrics {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .metric-card {
+            background: var(--card-bg);
+            border: 1px solid rgba(217, 226, 242, 0.7);
+            border-radius: var(--radius-md);
+            padding: 1.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            box-shadow: var(--shadow);
+        }
+
+        .metric-card span {
+            color: var(--text-secondary);
+            font-weight: 500;
+            font-size: 0.85rem;
+        }
+
+        .metric-value {
+            font-size: 2rem;
+            font-weight: 700;
+        }
+
+        .metric-delta {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--accent);
+        }
+
+        .timeline {
+            margin-top: 2.5rem;
+            background: var(--card-bg);
+            border-radius: var(--radius-md);
+            border: 1px solid rgba(217, 226, 242, 0.7);
+            padding: 2rem;
+            box-shadow: var(--shadow);
+        }
+
+        .timeline ol {
+            list-style: none;
+            display: grid;
+            gap: 1.8rem;
+            counter-reset: steps;
+        }
+
+        .timeline li {
+            counter-increment: steps;
+            position: relative;
+            padding-left: 3rem;
+        }
+
+        .timeline li::before {
+            content: counter(steps);
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 2.1rem;
+            height: 2.1rem;
+            border-radius: 50%;
+            background: rgba(53, 102, 255, 0.12);
+            color: var(--primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+        }
+
+        .timeline h3 {
+            font-size: 1.05rem;
+            margin-bottom: 0.35rem;
+        }
+
+        .timeline p {
+            color: var(--text-secondary);
+            font-size: 0.92rem;
+            line-height: 1.5;
+        }
+
+        .environment-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .environment-card {
+            background: var(--card-bg);
+            border-radius: var(--radius-md);
+            border: 1px solid rgba(217, 226, 242, 0.7);
+            padding: 1.75rem;
+            display: grid;
+            gap: 0.75rem;
+            box-shadow: var(--shadow);
+        }
+
+        .environment-card h3 {
+            font-size: 1.1rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .pill {
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 0.3rem 0.65rem;
+            border-radius: 999px;
+            background: rgba(15, 27, 61, 0.06);
+            color: var(--text-secondary);
+        }
+
+        .pill.success {
+            background: rgba(0, 184, 148, 0.12);
+            color: var(--accent);
+        }
+
+        .pill.warning {
+            background: rgba(255, 188, 66, 0.16);
+            color: #cc7a00;
+        }
+
+        .environment-card ul {
+            list-style: none;
+            display: grid;
+            gap: 0.45rem;
+            color: var(--text-secondary);
+            font-size: 0.92rem;
+        }
+
+        .checklist {
+            background: var(--card-bg);
+            border-radius: var(--radius-md);
+            border: 1px solid rgba(217, 226, 242, 0.7);
+            padding: 2rem;
+            box-shadow: var(--shadow);
+            display: grid;
+            gap: 1.25rem;
+        }
+
+        .checklist-item {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 1rem;
+            align-items: center;
+        }
+
+        .checklist input[type="checkbox"] {
+            width: 1.1rem;
+            height: 1.1rem;
+            accent-color: var(--primary);
+        }
+
+        .checklist label {
+            font-size: 0.95rem;
+            color: var(--text-secondary);
+        }
+
+        footer {
+            padding: 2.5rem 6vw 3rem;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+        }
+
+        footer a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        @media (max-width: 1024px) {
+            header {
+                flex-direction: column;
+                gap: 1rem;
+                align-items: flex-start;
             }
-            
-            .heading {
-                font-size: 1.25rem;
+
+            nav {
+                order: 3;
+            }
+
+            .hero {
+                grid-template-columns: 1fr;
+            }
+
+            .hero-card {
+                order: -1;
+            }
+        }
+
+        @media (max-width: 720px) {
+            header {
+                padding: 1.25rem 1.5rem 1rem;
+            }
+
+            main {
+                padding: 0 1.5rem 3rem;
+            }
+
+            .section {
+                margin-bottom: 3rem;
+            }
+        }
+
+        @media (max-width: 520px) {
+            .action-buttons {
+                flex-direction: column;
+                align-items: stretch;
             }
         }
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="content">
-            <!-- Document Approval View -->
-            <div id="approval-view">
-                <!-- Document Icon -->
-                <div class="icon-container">
-                    <div class="icon-circle">
-                        <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-                        </svg>
-                    </div>
-                </div>
-
-                <!-- Main Heading -->
-                <h1 class="heading">Document Received</h1>
-
-                <!-- Subtitle -->
-                <p class="subtitle">Review the document details below.</p>
-
-                <!-- Action Buttons -->
-                <div class="button-container">
-                    <button class="button button-approve" onclick="handleOpenDocument()">
-                        <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
-                        </svg>
-                        Open Document
-                    </button>
-
-                    <button class="button button-reject" onclick="handleDownloadDocument()">
-                        Download Document
-                    </button>
-                </div>
+    <div class="page">
+        <header>
+            <div class="logo" aria-label="DeployOps">
+                <span class="logo-badge">DP</span>
+                <span>DeployOps Control Center</span>
             </div>
+            <nav aria-label="Primary navigation">
+                <a href="#release-overview">Release</a>
+                <a href="#environments">Environments</a>
+                <a href="#checklist">Checklist</a>
+            </nav>
+        </header>
 
-            <!-- Processing View -->
-            <div id="processing-view" class="hidden">
-                <!-- Document Icon -->
-                <div class="icon-container">
-                    <div class="icon-circle">
-                        <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-                        </svg>
+        <main>
+            <section class="hero">
+                <article>
+                    <h1>Launch reliable releases with real-time visibility.</h1>
+                    <p>
+                        Coordinate your next deployment with centralized release notes, automated quality
+                        checks, and environment health in a single command center built for velocity.
+                    </p>
+                    <div class="action-buttons">
+                        <a class="btn primary" href="#release-overview">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M9 18l6-6-6-6" />
+                            </svg>
+                            View Release Plan
+                        </a>
+                        <button class="btn secondary" type="button" id="scheduleButton">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <circle cx="12" cy="12" r="9" />
+                                <polyline points="12 7 12 12 15 15" />
+                            </svg>
+                            Schedule Window
+                        </button>
                     </div>
+                </article>
+
+                <aside class="hero-card" aria-labelledby="release-card-title">
+                    <div class="card-header">
+                        <h2 id="release-card-title">Next deployment window</h2>
+                        <div class="status-badge">
+                            <span>
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <polyline points="20 6 9 17 4 12" />
+                                </svg>
+                                Ready
+                            </span>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <p class="summary">
+                            The release candidate has passed automated smoke, regression, and security checks.
+                            Final validation is scheduled ahead of production deployment.
+                        </p>
+                        <div class="deployment-stats">
+                            <div class="stat">
+                                <span>Launch In</span>
+                                <span id="launch-countdown">--:--:--</span>
+                            </div>
+                            <div class="stat">
+                                <span>Change Sets</span>
+                                <span>12</span>
+                            </div>
+                            <div class="stat">
+                                <span>Rollbacks</span>
+                                <span>0</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-footer">
+                        <span>
+                            Deployment manager
+                            <strong>Alex Rivers</strong>
+                        </span>
+                        <button type="button" id="notifyButton">Notify team</button>
+                    </div>
+                </aside>
+            </section>
+
+            <section class="section" id="release-overview">
+                <div class="section-heading">
+                    <div>
+                        <h2>Release overview</h2>
+                        <p>Performance, scope, and confidence indicators for the upcoming deployment.</p>
+                    </div>
+                    <span class="pill">Release: 2024.11.3</span>
                 </div>
 
-                <!-- Main Heading -->
-                <h1 class="heading">Processing Document</h1>
-
-                <!-- Subtitle -->
-                <p class="subtitle" id="processing-subtitle">Please wait while we process your request...</p>
-
-                <!-- Progress Bar -->
-                <div class="progress-container">
-                    <div class="progress-bar">
-                        <div class="progress-fill" id="progress-fill"></div>
-                    </div>
-                    <p class="progress-text" id="progress-text">0% complete</p>
+                <div class="metrics" role="list">
+                    <article class="metric-card" role="listitem">
+                        <span>Quality gate</span>
+                        <span class="metric-value">98%</span>
+                        <span class="metric-delta">+2% vs last release</span>
+                    </article>
+                    <article class="metric-card" role="listitem">
+                        <span>Error budget</span>
+                        <span class="metric-value">92%</span>
+                        <span class="metric-delta">Healthy</span>
+                    </article>
+                    <article class="metric-card" role="listitem">
+                        <span>Automation coverage</span>
+                        <span class="metric-value">183</span>
+                        <span class="metric-delta">Automated checks</span>
+                    </article>
+                    <article class="metric-card" role="listitem">
+                        <span>Approvals complete</span>
+                        <span class="metric-value">5 / 6</span>
+                        <span class="metric-delta">Awaiting final sign-off</span>
+                    </article>
                 </div>
-            </div>
-        </div>
+
+                <div class="timeline" aria-label="Release timeline">
+                    <ol>
+                        <li>
+                            <h3>Code freeze</h3>
+                            <p>Feature flags locked and stories moved to ready-for-release. Additional hotfixes require SRE approval.</p>
+                        </li>
+                        <li>
+                            <h3>Pre-production validation</h3>
+                            <p>Automated regression passes across staging, with chaos experiments verifying resilience thresholds.</p>
+                        </li>
+                        <li>
+                            <h3>Change review</h3>
+                            <p>Incident response plan updated, communications drafted, and release notes distributed to stakeholders.</p>
+                        </li>
+                        <li>
+                            <h3>Production go-live</h3>
+                            <p>Rolling deployment begins with observability guardrails and automated rollback triggers configured.</p>
+                        </li>
+                    </ol>
+                </div>
+            </section>
+
+            <section class="section" id="environments">
+                <div class="section-heading">
+                    <div>
+                        <h2>Environment readiness</h2>
+                        <p>Infrastructure health and verification across each promotion stage.</p>
+                    </div>
+                    <span class="pill success">Monitored</span>
+                </div>
+
+                <div class="environment-grid">
+                    <article class="environment-card" aria-label="Development environment">
+                        <h3>Development <span class="pill success">Stable</span></h3>
+                        <ul>
+                            <li>✅ Build pipeline cleared</li>
+                            <li>✅ Feature toggles verified</li>
+                            <li>✅ Load tests executed</li>
+                        </ul>
+                    </article>
+
+                    <article class="environment-card" aria-label="Staging environment">
+                        <h3>Staging <span class="pill success">Healthy</span></h3>
+                        <ul>
+                            <li>✅ Synthetic monitoring green</li>
+                            <li>✅ Database migrations rehearsed</li>
+                            <li>✅ Canary checks complete</li>
+                        </ul>
+                    </article>
+
+                    <article class="environment-card" aria-label="Production environment">
+                        <h3>Production <span class="pill warning">Attention</span></h3>
+                        <ul>
+                            <li>⚠️ Final approval pending</li>
+                            <li>✅ Rollback plan rehearsed</li>
+                            <li>✅ Observability alerts primed</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="section" id="checklist">
+                <div class="section-heading">
+                    <div>
+                        <h2>Launch checklist</h2>
+                        <p>Confirm critical tasks before toggling the deploy switch.</p>
+                    </div>
+                    <span class="pill">Owned by SRE</span>
+                </div>
+
+                <form class="checklist" aria-label="Deployment checklist">
+                    <div class="checklist-item">
+                        <input type="checkbox" id="checklist-1" checked disabled />
+                        <label for="checklist-1">All automated tests green across supported platforms.</label>
+                    </div>
+                    <div class="checklist-item">
+                        <input type="checkbox" id="checklist-2" checked disabled />
+                        <label for="checklist-2">Release notes communicated to customer success and support.</label>
+                    </div>
+                    <div class="checklist-item">
+                        <input type="checkbox" id="checklist-3" />
+                        <label for="checklist-3">Incident commander and on-call engineers confirmed.</label>
+                    </div>
+                    <div class="checklist-item">
+                        <input type="checkbox" id="checklist-4" />
+                        <label for="checklist-4">Change management ticket approved for production rollout.</label>
+                    </div>
+                </form>
+            </section>
+        </main>
+
+        <footer>
+            &copy; <span id="current-year"></span> DeployOps. All systems observed. <a href="#">View status page</a>.
+        </footer>
     </div>
 
     <script>
-        let currentProgress = 0;
-        let progressInterval;
+        const launchCountdown = document.getElementById('launch-countdown');
+        const scheduleButton = document.getElementById('scheduleButton');
+        const notifyButton = document.getElementById('notifyButton');
+        const currentYear = document.getElementById('current-year');
 
-        function showApprovalView() {
-            document.getElementById('approval-view').classList.remove('hidden');
-            document.getElementById('processing-view').classList.add('hidden');
+        currentYear.textContent = new Date().getFullYear();
+
+        const target = new Date();
+        target.setHours(target.getHours() + 4, 0, 0, 0);
+
+        function updateCountdown() {
+            const now = new Date();
+            const diff = Math.max(0, target - now);
+
+            const hours = String(Math.floor(diff / (1000 * 60 * 60))).padStart(2, '0');
+            const minutes = String(Math.floor((diff / (1000 * 60)) % 60)).padStart(2, '0');
+            const seconds = String(Math.floor((diff / 1000) % 60)).padStart(2, '0');
+
+            launchCountdown.textContent = `${hours}:${minutes}:${seconds}`;
         }
 
-        function showProcessingView(action) {
-            document.getElementById('approval-view').classList.add('hidden');
-            document.getElementById('processing-view').classList.remove('hidden');
-            
-            // Update subtitle based on action
-            const subtitle = document.getElementById('processing-subtitle');
-            const actionText = action === 'open' ? 'opening' : 'downloading';
-            subtitle.textContent = `Please wait while we ${actionText} your request...`;
-            
-            // Reset progress
-            currentProgress = 0;
-            updateProgress();
-            
-            // Start progress animation
-            startProgress();
-        }
+        updateCountdown();
+        setInterval(updateCountdown, 1000);
 
-        function updateProgress() {
-            const progressFill = document.getElementById('progress-fill');
-            const progressText = document.getElementById('progress-text');
-            
-            progressFill.style.width = currentProgress + '%';
-            progressText.textContent = currentProgress + '% complete';
-        }
+        scheduleButton.addEventListener('click', () => {
+            alert('Schedule sent to calendar. Team will be notified once approved.');
+        });
 
-        function startProgress() {
-            if (progressInterval) {
-                clearInterval(progressInterval);
-            }
-            
-            progressInterval = setInterval(() => {
-                currentProgress += 10;
-                updateProgress();
-                
-                if (currentProgress >= 100) {
-                    clearInterval(progressInterval);
-                    // Wait a moment then return to approval view
-                    setTimeout(() => {
-                        showApprovalView();
-                    }, 1000);
-                }
-            }, 300);
-        }
-
-        function handleOpenDocument() {
-            console.log('Opening document');
-            window.open('https://greenovaf.eu/', '_blank');
-        }
-
-        function handleDownloadDocument() {
-            console.log('Downloading document');
-            window.open('https://greenovaf.eu/', '_blank');
-        }
-
-        // Initialize the page
-        document.addEventListener('DOMContentLoaded', function() {
-            showApprovalView();
+        notifyButton.addEventListener('click', () => {
+            alert('Notification sent to release channel.');
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- redesign the landing page into a deployment control center with hero actions and a release readiness card
- add sections for release metrics, timeline milestones, environment health, and a launch checklist
- include a live deployment countdown along with quick actions to schedule the window or notify the team

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68ca8361b9c88331b1552b1493e90175